### PR TITLE
Fix ods include paths in macro, allowing for new dialects

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -66,6 +66,9 @@
     "trunci",
     "unranked",
     "vulkan",
-    "xori"
+    "xori",
+    "LLVMIR",
+    "somepathto",
+    "Bufferizable"
   ]
 }

--- a/macro/src/dialect.rs
+++ b/macro/src/dialect.rs
@@ -16,13 +16,27 @@ use operation::Operation;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use std::{env, fmt::Display, str};
+use std::{env, fmt::Display, path::Path, str};
 use tblgen::{record::Record, record_keeper::RecordKeeper, TableGenParser};
 
 pub fn generate_dialect(input: DialectInput) -> Result<TokenStream, Box<dyn std::error::Error>> {
     let mut parser = TableGenParser::new();
 
     if let Some(source) = input.table_gen() {
+        let base = Path::new(env!("LLVM_INCLUDE_DIRECTORY"));
+
+        // Here source looks like " include "somepathto.td" include "somepathto2.td" "
+        for (i, p) in source.split_ascii_whitespace().enumerate() {
+            if i % 2 == 0 {
+                continue; // skip "include"
+            }
+
+            let x = &p[1..(p.len() - 1)]; // remove ""
+            let path = Path::new(x).parent().unwrap();
+            let path = base.join(path);
+            parser = parser.add_include_path(&path.to_string_lossy());
+        }
+
         parser = parser.add_source(source).map_err(create_syn_error)?;
     }
 

--- a/melior/src/dialect/ods.rs
+++ b/melior/src/dialect/ods.rs
@@ -65,7 +65,7 @@ melior_macro::dialect! {
 }
 melior_macro::dialect! {
     name: "irdl",
-    table_gen: r#"include "mlir/Dialect/IRDL/IR/IRDL.td""#
+    table_gen: r#"include "mlir/Dialect/IRDL/IR/IRDLOps.td""#
 }
 melior_macro::dialect! {
     name: "llvm",

--- a/melior/src/dialect/ods.rs
+++ b/melior/src/dialect/ods.rs
@@ -9,11 +9,14 @@ pub mod __private {
 
 melior_macro::dialect! {
     name: "affine",
-    table_gen: r#"include "mlir/Dialect/Affine/IR/AffineOps.td""#
+    table_gen: r#"include "mlir/Dialect/Affine/IR/AffineOps.td"
+        include "mlir/Dialect/Affine/TransformOps/AffineTransformOps.td"
+        include "mlir/Dialect/Affine/IR/AffineMemoryOpInterfaces.td""#
 }
 melior_macro::dialect! {
     name: "amdgpu",
-    table_gen: r#"include "mlir/Dialect/AMDGPU/IR/AMDGPU.td""#
+    table_gen: r#"include "mlir/Dialect/AMDGPU/IR/AMDGPU.td"
+    include "mlir/Dialect/AMDGPU/Transforms/Passes.td""#
 }
 melior_macro::dialect! {
     name: "arith",
@@ -28,8 +31,16 @@ melior_macro::dialect! {
     table_gen: r#"include "mlir/Dialect/ArmSVE/IR/ArmSVE.td""#
 }
 melior_macro::dialect! {
+    name: "arm_sme",
+    table_gen: r#"include "mlir/Dialect/ArmSME/IR/ArmSME.td"
+        include "mlir/Dialect/ArmSME/IR/ArmSMEOps.td"
+        include "mlir/Dialect/ArmSME/IR/ArmSMEIntrinsicOps.td""#
+}
+melior_macro::dialect! {
     name: "async",
-    table_gen: r#"include "mlir/Dialect/Async/IR/AsyncOps.td""#
+    table_gen: r#"include "mlir/Dialect/Async/IR/AsyncDialect.td"
+        include "mlir/Dialect/Async/IR/AsyncOps.td"
+        include "mlir/Dialect/Async/IR/AsyncTypes.td""#
 }
 melior_macro::dialect! {
     name: "amx",
@@ -41,7 +52,13 @@ melior_macro::dialect! {
 }
 melior_macro::dialect! {
     name: "bufferization",
-    table_gen: r#"include "mlir/Dialect/Bufferization/IR/BufferizationOps.td""#
+    table_gen: r#"include "mlir/Dialect/Bufferization/IR/BufferizationOps.td"
+        include "mlir/Dialect/Bufferization/IR/AllocationOpInterface.td"
+        include "mlir/Dialect/Bufferization/IR/BufferizationEnums.td"
+        include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.td"
+        include "mlir/Dialect/Bufferization/TransformOps/BufferizationTransformOps.td"
+        include "mlir/Dialect/Bufferization/Transforms/Passes.td"
+    "#
 }
 melior_macro::dialect! {
     name: "complex",
@@ -53,11 +70,15 @@ melior_macro::dialect! {
 }
 melior_macro::dialect! {
     name: "dlti",
-    table_gen: r#"include "mlir/Dialect/DLTI/DLTI.td""#
+    table_gen: r#"include "mlir/Dialect/DLTI/DLTI.td"
+        include "mlir/Dialect/DLTI/DLTIAttrs.td"
+        include "mlir/Dialect/DLTI/DLTIBase.td""#
 }
 melior_macro::dialect! {
     name: "func",
-    table_gen: r#"include "mlir/Dialect/Func/IR/FuncOps.td""#
+    table_gen: r#"include "mlir/Dialect/Func/IR/FuncOps.td"
+        include "mlir/Dialect/Func/TransformOps/FuncTransformOps.td"
+        include "mlir/Dialect/Func/Transforms/Passes.td""#
 }
 melior_macro::dialect! {
     name: "index",
@@ -65,12 +86,19 @@ melior_macro::dialect! {
 }
 melior_macro::dialect! {
     name: "irdl",
-    table_gen: r#"include "mlir/Dialect/IRDL/IR/IRDLOps.td""#
+    table_gen: r#"include "mlir/Dialect/IRDL/IR/IRDL.td" include "mlir/Dialect/IRDL/IR/IRDLOps.td""#
 }
 melior_macro::dialect! {
     name: "llvm",
     // spell-checker: disable-next-line
-    table_gen: r#"include "mlir/Dialect/LLVMIR/LLVMOps.td" include "mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td""#
+    table_gen: r#"include "mlir/Dialect/LLVMIR/LLVMOps.td"
+        include "mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td"
+        include "mlir/Dialect/LLVMIR/LLVMDialect.td"
+        include "mlir/Dialect/LLVMIR/LLVMInterfaces.td"
+        include "mlir/Dialect/LLVMIR/LLVMTypes.td"
+        include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
+        include "mlir/Dialect/LLVMIR/LLVMAttrDefs.td"
+        include "mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.td""#
 }
 melior_macro::dialect! {
     name: "memref",

--- a/melior/src/utility.rs
+++ b/melior/src/utility.rs
@@ -1,10 +1,12 @@
 //! Utility functions.
 
 use crate::{
-    context::Context, dialect::DialectRegistry, ir::Module, logical_result::LogicalResult, pass, string_ref::StringRef, Error
+    context::Context, dialect::DialectRegistry, ir::Module, logical_result::LogicalResult, pass,
+    string_ref::StringRef, Error,
 };
 use mlir_sys::{
-    mlirLoadIRDLDialects, mlirParsePassPipeline, mlirRegisterAllDialects, mlirRegisterAllLLVMTranslations, mlirRegisterAllPasses, MlirStringRef
+    mlirLoadIRDLDialects, mlirParsePassPipeline, mlirRegisterAllDialects,
+    mlirRegisterAllLLVMTranslations, mlirRegisterAllPasses, MlirStringRef,
 };
 use std::{
     ffi::c_void,
@@ -54,9 +56,7 @@ pub fn parse_pass_pipeline(manager: pass::OperationPassManager, source: &str) ->
 
 /// Loads all IRDL dialects in the provided module, registering the dialects in the module's associated context.
 pub fn load_irdl_dialects(module: &Module) -> bool {
-    unsafe {
-        mlirLoadIRDLDialects(module.to_raw()).value == 1
-    }
+    unsafe { mlirLoadIRDLDialects(module.to_raw()).value == 1 }
 }
 
 unsafe extern "C" fn handle_parse_error(raw_string: MlirStringRef, data: *mut c_void) {


### PR DESCRIPTION
This fixes support for the following dialects in ODS like IRDL

Fixes #540 

This pr includes #639