### PR TITLE
Add missing LLVM operations

### DIFF
--- a/melior/src/dialect/llvm.rs
+++ b/melior/src/dialect/llvm.rs
@@ -260,7 +260,8 @@ pub fn call_intrinsic<'c>(
             ),
             (
                 Identifier::new(context, "op_bundle_sizes"),
-                // Total sizes: First segment (callee) has 1 operand, second segment (args) has args.len() operands
+                // Total sizes: First segment (callee) has 1 operand, second segment (args) has
+                // args.len() operands
                 DenseI32ArrayAttribute::new(context, &[]).into(),
             ),
         ])
@@ -532,7 +533,8 @@ pub fn call<'a>(
             ),
             (
                 Identifier::new(context, "op_bundle_sizes"),
-                // Total sizes: First segment (callee) has 1 operand, second segment (args) has args.len() operands
+                // Total sizes: First segment (callee) has 1 operand, second segment (args) has
+                // args.len() operands
                 DenseI32ArrayAttribute::new(context, &[]).into(),
             ),
         ])
@@ -565,7 +567,8 @@ pub fn indirect_call<'a>(
             ),
             (
                 Identifier::new(context, "op_bundle_sizes"),
-                // Total sizes: First segment (callee) has 1 operand, second segment (args) has args.len() operands
+                // Total sizes: First segment (callee) has 1 operand, second segment (args) has
+                // args.len() operands
                 DenseI32ArrayAttribute::new(context, &[]).into(),
             ),
         ]) // Default calling convention

--- a/melior/src/dialect/llvm.rs
+++ b/melior/src/dialect/llvm.rs
@@ -371,10 +371,11 @@ pub fn zext<'c>(
 
 /// Creates an `llvm.icmp` operation in Melior.
 /// This is used to create integer AND pointer comparisons, unlike arith::icmp.
-/// The predicate is an enum that specifies the type of comparison to be performed.
-/// The result type is always a 1-bit integer (boolean).
+/// The predicate is an enum that specifies the type of comparison to be
+/// performed. The result type is always a 1-bit integer (boolean).
 /// The `lhs` and `rhs` operands are the values to be compared.
-/// The `location` parameter specifies the location of the operation in the source code.
+/// The `location` parameter specifies the location of the operation in the
+/// source code.
 pub fn icmp<'a>(
     context: &'a Context,
     predicate: ICmpPredicate,
@@ -393,7 +394,8 @@ pub fn icmp<'a>(
         .unwrap()
 }
 
-/// Creates an `llvm.mlir.addressof` operation to get a pointer to a global variable.
+/// Creates an `llvm.mlir.addressof` operation to get a pointer to a global
+/// variable.
 pub fn addressof<'a>(
     context: &'a Context,
     global_name: &str,
@@ -509,7 +511,7 @@ pub fn call<'a>(
 }
 
 /// Creates an `llvm.call` operation in Melior.
-/// 
+///
 /// This can call any function from a pointer value.
 pub fn indirect_call<'a>(
     callee: Value<'a, '_>,
@@ -1445,7 +1447,12 @@ mod tests {
             &context,
             StringAttribute::new(&context, "foo"),
             TypeAttribute::new(
-                FunctionType::new(&context, &[integer_type, integer_type], &[IntegerType::new(&context, 1).into()]).into(),
+                FunctionType::new(
+                    &context,
+                    &[integer_type, integer_type],
+                    &[IntegerType::new(&context, 1).into()],
+                )
+                .into(),
             ),
             {
                 let block = Block::new(&[(integer_type, location), (integer_type, location)]);
@@ -1506,12 +1513,7 @@ mod tests {
                 let block = Block::new(&[]);
 
                 let res = block
-                    .append_operation(addressof(
-                        &context,
-                        "my_global",
-                        ptr_type,
-                        location,
-                    ))
+                    .append_operation(addressof(&context, "my_global", ptr_type, location))
                     .result(0)
                     .unwrap()
                     .into();
@@ -1667,7 +1669,9 @@ mod tests {
         module.body().append_operation(func::func(
             &context,
             StringAttribute::new(&context, "caller"),
-            TypeAttribute::new(FunctionType::new(&context, &[integer_type], &[integer_type]).into()),
+            TypeAttribute::new(
+                FunctionType::new(&context, &[integer_type], &[integer_type]).into(),
+            ),
             {
                 let block = Block::new(&[(integer_type, location)]);
 
@@ -1712,7 +1716,9 @@ mod tests {
         module.body().append_operation(func::func(
             &context,
             StringAttribute::new(&context, "call_fn_ptr"),
-            TypeAttribute::new(FunctionType::new(&context, &[fn_ptr_type, integer_type], &[integer_type]).into()),
+            TypeAttribute::new(
+                FunctionType::new(&context, &[fn_ptr_type, integer_type], &[integer_type]).into(),
+            ),
             {
                 let block = Block::new(&[(fn_ptr_type, location), (integer_type, location)]);
 
@@ -1754,7 +1760,9 @@ mod tests {
         module.body().append_operation(func::func(
             &context,
             StringAttribute::new(&context, "use_intrinsic"),
-            TypeAttribute::new(FunctionType::new(&context, &[integer_type], &[integer_type]).into()),
+            TypeAttribute::new(
+                FunctionType::new(&context, &[integer_type], &[integer_type]).into(),
+            ),
             {
                 let block = Block::new(&[(integer_type, location)]);
 

--- a/melior/src/dialect/llvm.rs
+++ b/melior/src/dialect/llvm.rs
@@ -13,7 +13,7 @@ use crate::{
     Context,
 };
 pub use alloca_options::*;
-use attributes::Linkage;
+use attributes::{ICmpPredicate, Linkage};
 use global::GlobalValue;
 pub use load_store_options::*;
 
@@ -369,69 +369,6 @@ pub fn zext<'c>(
         .expect("valid operation")
 }
 
-// https://github.com/llvm/llvm-project/blob/600eeed51f538adc5f43c8223a57608e73aba31f/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td#L542-L558
-/// LLVM float comparison predicates.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u64)]
-pub enum FCmpPredicate {
-    /// Always returns false.
-    False = 0,
-    /// Ordered and equal.
-    Oeq = 1,
-    /// Ordered and greater than.
-    Ogt = 2,
-    /// Ordered and greater than or equal.
-    Oge = 3,
-    /// Ordered and less than.
-    Olt = 4,
-    /// Ordered and less than or equal.
-    Ole = 5,
-    /// Ordered and not equal.
-    One = 6,
-    /// Ordered (no NaNs).
-    Ord = 7,
-    /// Unordered or equal.
-    Ueq = 8,
-    /// Unordered or greater than.
-    Ugt = 9,
-    /// Unordered or greater than or equal.
-    Uge = 10,
-    /// Unordered or less than.
-    Ult = 11,
-    /// Unordered or less than or equal.
-    Ule = 12,
-    /// Unordered or not equal.
-    Une = 13,
-    /// Unordered (either NaNs).
-    Uno = 14,
-    /// Always returns true.
-    True = 15,
-}
-/// LLVM integer comparison predicates.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u64)]
-pub enum ICmpPredicate {
-    /// Equal
-    Eq = 0,
-    /// Not equal
-    Ne = 1,
-    /// Signed less than
-    Slt = 2,
-    /// Signed less than or equal
-    Sle = 3,
-    /// Signed greater than
-    Sgt = 4,
-    /// Signed greater than or equal
-    Sge = 5,
-    /// Unsigned less than
-    Ult = 6,
-    /// Unsigned less than or equal
-    Ule = 7,
-    /// Unsigned greater than
-    Ugt = 8,
-    /// Unsigned greater than or equal
-    Uge = 9,
-}
 /// Creates an `llvm.icmp` operation in Melior.
 /// This is used to create integer AND pointer comparisons, unlike arith::icmp.
 /// The predicate is an enum that specifies the type of comparison to be performed.

--- a/melior/src/dialect/llvm.rs
+++ b/melior/src/dialect/llvm.rs
@@ -488,6 +488,8 @@ pub fn constant<'a>(
         .unwrap()
 }
 
+/// Creates an `llvm.call` operation in Melior.
+/// Used for calling functions declared through LLVM dialect.
 pub fn call<'a>(
     context: &'a Context,
     callee: &str,
@@ -506,6 +508,9 @@ pub fn call<'a>(
         .unwrap()
 }
 
+/// Creates an `llvm.call` operation in Melior.
+/// 
+/// This can call any function from a pointer value.
 pub fn indirect_call<'a>(
     callee: Value<'a, '_>,
     args: &[Value<'a, '_>],

--- a/melior/src/dialect/llvm/attributes.rs
+++ b/melior/src/dialect/llvm/attributes.rs
@@ -26,3 +26,67 @@ pub fn linkage(context: &Context, linkage: Linkage) -> Attribute {
     };
     Attribute::parse(context, &format!("#llvm.linkage<{linkage}>")).unwrap()
 }
+
+// https://github.com/llvm/llvm-project/blob/600eeed51f538adc5f43c8223a57608e73aba31f/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td#L542-L558
+/// LLVM float comparison predicates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u64)]
+pub enum FCmpPredicate {
+    /// Always returns false.
+    False = 0,
+    /// Ordered and equal.
+    Oeq = 1,
+    /// Ordered and greater than.
+    Ogt = 2,
+    /// Ordered and greater than or equal.
+    Oge = 3,
+    /// Ordered and less than.
+    Olt = 4,
+    /// Ordered and less than or equal.
+    Ole = 5,
+    /// Ordered and not equal.
+    One = 6,
+    /// Ordered (no NaNs).
+    Ord = 7,
+    /// Unordered or equal.
+    Ueq = 8,
+    /// Unordered or greater than.
+    Ugt = 9,
+    /// Unordered or greater than or equal.
+    Uge = 10,
+    /// Unordered or less than.
+    Ult = 11,
+    /// Unordered or less than or equal.
+    Ule = 12,
+    /// Unordered or not equal.
+    Une = 13,
+    /// Unordered (either NaNs).
+    Uno = 14,
+    /// Always returns true.
+    True = 15,
+}
+/// LLVM integer comparison predicates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u64)]
+pub enum ICmpPredicate {
+    /// Equal
+    Eq = 0,
+    /// Not equal
+    Ne = 1,
+    /// Signed less than
+    Slt = 2,
+    /// Signed less than or equal
+    Sle = 3,
+    /// Signed greater than
+    Sgt = 4,
+    /// Signed greater than or equal
+    Sge = 5,
+    /// Unsigned less than
+    Ult = 6,
+    /// Unsigned less than or equal
+    Ule = 7,
+    /// Unsigned greater than
+    Ugt = 8,
+    /// Unsigned greater than or equal
+    Uge = 9,
+}

--- a/melior/src/dialect/llvm/global.rs
+++ b/melior/src/dialect/llvm/global.rs
@@ -1,4 +1,7 @@
-use crate::{dialect::llvm::attributes::Linkage, ir::{Attribute, Region}};
+use crate::{
+    dialect::llvm::attributes::Linkage,
+    ir::{Attribute, Region},
+};
 
 pub enum GlobalValue<'c> {
     /// A global variable.

--- a/melior/src/dialect/llvm/global.rs
+++ b/melior/src/dialect/llvm/global.rs
@@ -1,0 +1,38 @@
+use crate::{dialect::llvm::attributes::Linkage, ir::{Attribute, Region}};
+
+pub enum GlobalValue<'c> {
+    /// A global variable.
+    Value(Attribute<'c>),
+    /// A global variable with a constant initializer.
+    Constant(Attribute<'c>),
+    /// A global variable with a constant initializer and a body.
+    Complex(Region<'c>),
+}
+
+#[derive(Default)]
+pub struct GlobalVariableOptions {
+    pub(crate) addr_space: Option<i32>,
+    pub(crate) alignment: Option<i64>,
+    pub(crate) linkage: Option<Linkage>,
+}
+
+impl GlobalVariableOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn addr_space(mut self, addr_space: i32) -> Self {
+        self.addr_space = Some(addr_space);
+        self
+    }
+
+    pub fn alignment(mut self, alignment: i64) -> Self {
+        self.alignment = Some(alignment);
+        self
+    }
+
+    pub fn linkage(mut self, linkage: Linkage) -> Self {
+        self.linkage = Some(linkage);
+        self
+    }
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_addressof.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_addressof.snap
@@ -1,0 +1,11 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.mlir.global internal constant @my_global(42 : i64) {addr_space = 0 : i32, alignment = 1 : i64} : i64
+  llvm.func @get_global_addr() -> !llvm.ptr {
+    %0 = llvm.mlir.addressof @my_global : !llvm.ptr
+    llvm.return %0 : !llvm.ptr
+  }
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_bitcast.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_bitcast.snap
@@ -1,0 +1,10 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.func @int_bits_to_float(%arg0: i32) -> f32 {
+    %0 = llvm.bitcast %arg0 : i32 to f32
+    llvm.return %0 : f32
+  }
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_call.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_call.snap
@@ -1,0 +1,15 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.func @add_one(%arg0: i32) -> i32 {
+    %0 = llvm.mlir.constant(1 : i32) : i32
+    %1 = llvm.add %arg0, %0 : i32
+    llvm.return %1 : i32
+  }
+  llvm.func @caller(%arg0: i32) -> i32 {
+    %0 = llvm.call @add_one(%arg0) : (i32) -> i32
+    llvm.return %0 : i32
+  }
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_call.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_call.snap
@@ -5,7 +5,7 @@ expression: module.as_operation()
 module {
   llvm.func @add_one(%arg0: i32) -> i32 {
     %0 = llvm.mlir.constant(1 : i32) : i32
-    %1 = llvm.add %arg0, %0 : i32
+    %1 = arith.addi %arg0, %0 : i32
     llvm.return %1 : i32
   }
   llvm.func @caller(%arg0: i32) -> i32 {

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_call_intrinsic.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_call_intrinsic.snap
@@ -1,0 +1,10 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.func @use_intrinsic(%arg0: i32) -> i32 {
+    %0 = llvm.call_intrinsic "llvm.bitreverse.i32"(%arg0) : (i32) -> i32
+    llvm.return %0 : i32
+  }
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_constant.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_constant.snap
@@ -1,0 +1,10 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.func @get_constant() -> i32 {
+    %0 = llvm.mlir.constant(42 : i32) : i32
+    llvm.return %0 : i32
+  }
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_global_variable.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_global_variable.snap
@@ -1,0 +1,8 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.mlir.global internal constant @const_global(42 : i32) {addr_space = 0 : i32, alignment = 4 : i64} : i32
+  llvm.mlir.global external @mutable_global(123 : i32) {addr_space = 0 : i32, alignment = 8 : i64} : i32
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_icmp.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_icmp.snap
@@ -1,0 +1,10 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.func @foo(%arg0: i64, %arg1: i64) -> i1 {
+    %0 = llvm.icmp "eq" %arg0, %arg1 : i64
+    llvm.return %0 : i1
+  }
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_indirect_call.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_indirect_call.snap
@@ -1,0 +1,10 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.func @call_fn_ptr(%arg0: !llvm.ptr, %arg1: i32) -> i32 {
+    %0 = llvm.call %arg0(%arg1) : !llvm.ptr, (i32) -> i32
+    llvm.return %0 : i32
+  }
+}

--- a/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_unreachable.snap
+++ b/melior/src/dialect/snapshots/melior__dialect__llvm__tests__compile_unreachable.snap
@@ -1,0 +1,9 @@
+---
+source: melior/src/dialect/llvm.rs
+expression: module.as_operation()
+---
+module {
+  llvm.func @func_with_unreachable() {
+    llvm.unreachable
+  }
+}


### PR DESCRIPTION
Decided to add some LLVM dialect operations I required in my project and now contribute them upstream. I am not sure about the efficacy of some implementations, specifically GlobalValue. So I'm leaving it in draft mode to allow for feedback.

Hopefully everything else is ok.
