### PR TITLE
Introduce OperationLike::walk

### DIFF
--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -647,25 +647,30 @@ mod tests {
 
         let operation = block.append_operation(
             OperationBuilder::new("parent", location)
-               .add_results(&[Type::index(&context)])
-               .add_regions([{
-                   let region = Region::new();
+                .add_results(&[Type::index(&context)])
+                .add_regions([{
+                    let region = Region::new();
 
-                   let block = Block::new(&[]);
-                   block.append_operation(OperationBuilder::new("child1", location).build().unwrap());
-                   block.append_operation(OperationBuilder::new("child2", location).build().unwrap());
+                    let block = Block::new(&[]);
+                    block.append_operation(
+                        OperationBuilder::new("child1", location).build().unwrap(),
+                    );
+                    block.append_operation(
+                        OperationBuilder::new("child2", location).build().unwrap(),
+                    );
 
-                   region.append_block(block);
-                   region
+                    region.append_block(block);
+                    region
                 }])
-               .build()
-               .unwrap(),
+                .build()
+                .unwrap(),
         );
 
         // test advance
         let mut result: Vec<String> = Vec::new();
         operation.walk_pre(|op| {
-            let name = op.name()
+            let name = op
+                .name()
                 .as_string_ref()
                 .as_str()
                 .expect("valid str")
@@ -678,7 +683,8 @@ mod tests {
         // test interrupt
         result.clear();
         operation.walk_pre(|op| {
-            let name = op.name()
+            let name = op
+                .name()
                 .as_string_ref()
                 .as_str()
                 .expect("valid str")
@@ -694,7 +700,8 @@ mod tests {
         // test skip
         result.clear();
         operation.walk_pre(|op| {
-            let name = op.name()
+            let name = op
+                .name()
                 .as_string_ref()
                 .as_str()
                 .expect("valid str")
@@ -715,32 +722,35 @@ mod tests {
 
         let operation = block.append_operation(
             OperationBuilder::new("grandparent", location)
-               .add_regions([{
-                   let region = Region::new();
-                   let block = Block::new(&[]);
-                   block.append_operation(
-                       OperationBuilder::new("parent", location)
-                           .add_regions([{
-                               let region = Region::new();
-                               let block = Block::new(&[]);
-                               block.append_operation(OperationBuilder::new("child", location).build().unwrap());
-                               region.append_block(block);
-                               region
-                           }])
-                           .build()
-                           .unwrap(),
-                   );
-                   region.append_block(block);
-                   region
+                .add_regions([{
+                    let region = Region::new();
+                    let block = Block::new(&[]);
+                    block.append_operation(
+                        OperationBuilder::new("parent", location)
+                            .add_regions([{
+                                let region = Region::new();
+                                let block = Block::new(&[]);
+                                block.append_operation(
+                                    OperationBuilder::new("child", location).build().unwrap(),
+                                );
+                                region.append_block(block);
+                                region
+                            }])
+                            .build()
+                            .unwrap(),
+                    );
+                    region.append_block(block);
+                    region
                 }])
-               .build()
-               .unwrap(),
+                .build()
+                .unwrap(),
         );
 
         // test advance
         let mut result: Vec<String> = Vec::new();
         operation.walk_post(|op| {
-            let name = op.name()
+            let name = op
+                .name()
                 .as_string_ref()
                 .as_str()
                 .expect("valid str")
@@ -753,7 +763,8 @@ mod tests {
         // test interrupt
         result.clear();
         operation.walk_post(|op| {
-            let name = op.name()
+            let name = op
+                .name()
                 .as_string_ref()
                 .as_str()
                 .expect("valid str")
@@ -771,7 +782,8 @@ mod tests {
         //     because walk_post visits children before a parent
         result.clear();
         operation.walk_post(|op| {
-            let name = op.name()
+            let name = op
+                .name()
                 .as_string_ref()
                 .as_str()
                 .expect("valid str")

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -639,6 +639,7 @@ mod tests {
 
     #[test]
     fn walk_pre() {
+        let pre = operation_like::WalkOrder::PreOrder;
         let context = create_test_context();
         context.set_allow_unregistered_dialects(true);
 
@@ -668,7 +669,7 @@ mod tests {
 
         // test advance
         let mut result: Vec<String> = Vec::new();
-        operation.walk_pre(|op| {
+        operation.walk(pre, |op| {
             let name = op
                 .name()
                 .as_string_ref()
@@ -682,7 +683,7 @@ mod tests {
 
         // test interrupt
         result.clear();
-        operation.walk_pre(|op| {
+        operation.walk(pre, |op| {
             let name = op
                 .name()
                 .as_string_ref()
@@ -699,7 +700,7 @@ mod tests {
 
         // test skip
         result.clear();
-        operation.walk_pre(|op| {
+        operation.walk(pre, |op| {
             let name = op
                 .name()
                 .as_string_ref()
@@ -714,6 +715,7 @@ mod tests {
 
     #[test]
     fn walk_post() {
+        let post = operation_like::WalkOrder::PostOrder;
         let context = create_test_context();
         context.set_allow_unregistered_dialects(true);
 
@@ -748,7 +750,7 @@ mod tests {
 
         // test advance
         let mut result: Vec<String> = Vec::new();
-        operation.walk_post(|op| {
+        operation.walk(post, |op| {
             let name = op
                 .name()
                 .as_string_ref()
@@ -762,7 +764,7 @@ mod tests {
 
         // test interrupt
         result.clear();
-        operation.walk_post(|op| {
+        operation.walk(post, |op| {
             let name = op
                 .name()
                 .as_string_ref()
@@ -778,10 +780,10 @@ mod tests {
         assert_eq!(vec!["child", "parent"], result);
 
         // test skip
-        // XXX it doesn't seem like there's a meaningful way to test skip with walk_post
-        //     because walk_post visits children before a parent
+        // XXX it doesn't seem like there's a meaningful way to test skip with post
+        //     because a post order walk visits children before a parent
         result.clear();
-        operation.walk_post(|op| {
+        operation.walk(post, |op| {
             let name = op
                 .name()
                 .as_string_ref()

--- a/melior/src/ir/operation.rs
+++ b/melior/src/ir/operation.rs
@@ -671,7 +671,7 @@ mod tests {
                 .expect("valid str")
                 .to_string();
             result.push(name);
-            operation_like::WalkAction::Advance
+            operation_like::WalkResult::Advance
         });
         assert_eq!(vec!["parent", "child1", "child2"], result);
 
@@ -685,8 +685,8 @@ mod tests {
                 .to_string();
             result.push(name.clone());
             match name.as_str() {
-                "parent" => operation_like::WalkAction::Advance,
-                _ => operation_like::WalkAction::Interrupt,
+                "parent" => operation_like::WalkResult::Advance,
+                _ => operation_like::WalkResult::Interrupt,
             }
         });
         assert_eq!(vec!["parent", "child1"], result);
@@ -700,7 +700,7 @@ mod tests {
                 .expect("valid str")
                 .to_string();
             result.push(name.clone());
-            operation_like::WalkAction::Skip
+            operation_like::WalkResult::Skip
         });
         assert_eq!(vec!["parent"], result);
     }
@@ -746,7 +746,7 @@ mod tests {
                 .expect("valid str")
                 .to_string();
             result.push(name);
-            operation_like::WalkAction::Advance
+            operation_like::WalkResult::Advance
         });
         assert_eq!(vec!["child", "parent", "grandparent"], result);
 
@@ -760,8 +760,8 @@ mod tests {
                 .to_string();
             result.push(name.clone());
             match name.as_str() {
-                "child" => operation_like::WalkAction::Advance,
-                _ => operation_like::WalkAction::Interrupt,
+                "child" => operation_like::WalkResult::Advance,
+                _ => operation_like::WalkResult::Interrupt,
             }
         });
         assert_eq!(vec!["child", "parent"], result);
@@ -777,7 +777,7 @@ mod tests {
                 .expect("valid str")
                 .to_string();
             result.push(name.clone());
-            operation_like::WalkAction::Skip
+            operation_like::WalkResult::Skip
         });
         assert_eq!(vec!["child", "parent", "grandparent"], result);
     }

--- a/melior/src/ir/operation/operation_like.rs
+++ b/melior/src/ir/operation/operation_like.rs
@@ -290,22 +290,6 @@ pub trait OperationLike<'c: 'a, 'a>: Display + 'a {
             mlirOperationWalk(self.to_raw(), Some(tramp::<F>), data, order as _);
         }
     }
-
-    /// Convenience for a pre-order walk.
-    fn walk_pre<F>(&self, callback: F)
-    where
-        F: for<'x, 'y> FnMut(OperationRef<'x, 'y>) -> WalkResult,
-    {
-        self.walk(WalkOrder::PreOrder, callback)
-    }
-
-    /// Convenience for a post-order walk.
-    fn walk_post<F>(&self, callback: F)
-    where
-        F: for<'x, 'y> FnMut(OperationRef<'x, 'y>) -> WalkResult,
-    {
-        self.walk(WalkOrder::PostOrder, callback)
-    }
 }
 
 pub trait OperationMutLike<'c: 'a, 'a>: OperationLike<'c, 'a> {

--- a/melior/src/ir/operation/operation_like.rs
+++ b/melior/src/ir/operation/operation_like.rs
@@ -264,7 +264,8 @@ pub trait OperationLike<'c: 'a, 'a>: Display + 'a {
         Ok(data.0)
     }
 
-    /// Walk this operation (and all nested operations) in either pre- or post-order.
+    /// Walk this operation (and all nested operations) in either pre- or
+    /// post-order.
     ///
     /// The closure is called once per operation; by returning
     /// `WalkResult::Advance`/`Skip`/`Interrupt` you control the traversal.

--- a/melior/src/ir/operation/operation_like.rs
+++ b/melior/src/ir/operation/operation_like.rs
@@ -9,6 +9,8 @@ use mlir_sys::{
     mlirOperationGetResult, mlirOperationGetSuccessor, mlirOperationPrintWithFlags,
     mlirOperationRemoveAttributeByName, mlirOperationRemoveFromParent,
     mlirOperationSetAttributeByName, mlirOperationVerify, MlirOperation,
+    mlirOperationWalk, MlirWalkOrder_MlirWalkPreOrder, MlirWalkOrder_MlirWalkPostOrder,
+    MlirWalkResult, MlirWalkResult_MlirWalkResultAdvance, MlirWalkResult_MlirWalkResultInterrupt, MlirWalkResult_MlirWalkResultSkip,
 };
 
 use crate::{
@@ -19,6 +21,28 @@ use crate::{
 use super::{
     print_string_callback, OperationPrintingFlags, OperationRef, OperationRefMut, OperationResult,
 };
+
+/// Order in which to traverse an operation tree.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum WalkOrder {
+    /// Visit the operation before its nested regions.
+    PreOrder  = MlirWalkOrder_MlirWalkPreOrder,
+    /// Visit the operation after its nested regions.
+    PostOrder = MlirWalkOrder_MlirWalkPostOrder,
+}
+
+/// Control flow action returned by the walk callback.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum WalkAction {
+    /// Continue into this operation’s children.
+    Advance   = MlirWalkResult_MlirWalkResultAdvance,
+    /// Terminate the entire walk immediately.
+    Interrupt = MlirWalkResult_MlirWalkResultInterrupt,
+    /// Don’t visit this operation’s children, but keep walking siblings.
+    Skip      = MlirWalkResult_MlirWalkResultSkip,
+}
 
 pub trait OperationLike<'c: 'a, 'a>: Display + 'a {
     /// Converts a value into a raw value.
@@ -237,6 +261,54 @@ pub trait OperationLike<'c: 'a, 'a>: Display + 'a {
         data.1?;
 
         Ok(data.0)
+    }
+
+    /// Walk this operation (and all nested operations) in either pre- or post-order.
+    ///
+    /// The closure is called once per operation; by returning
+    /// `WalkAction::Advance`/`Skip`/`Interrupt` you control the traversal.
+    fn walk<F>(&self, order: WalkOrder, mut callback: F)
+    where
+        F: for<'x,'y> FnMut(OperationRef<'x,'y>) -> WalkAction,
+    {
+        // trampoline from C to Rust
+        unsafe extern "C" fn tramp<F>(
+            raw: MlirOperation,
+            user_data: *mut std::os::raw::c_void,
+        ) -> MlirWalkResult
+        where
+            F: for<'x,'y> FnMut(OperationRef<'x,'y>) -> WalkAction,
+        {
+            let cb: &mut F = &mut *(user_data as *mut F);
+            let op = OperationRef::from_raw(raw);
+            (cb)(op) as MlirWalkResult
+        }
+
+        let data = &mut callback as *mut _ as *mut std::os::raw::c_void;
+        unsafe {
+            mlirOperationWalk(
+                self.to_raw(),
+                Some(tramp::<F>),
+                data,
+                order as _,
+            );
+        }
+    }
+
+    /// Convenience for a pre-order walk.
+    fn walk_pre<F>(&self, callback: F)
+    where
+        F: for<'x,'y> FnMut(OperationRef<'x,'y>) -> WalkAction,
+    {
+        self.walk(WalkOrder::PreOrder, callback)
+    }
+
+    /// Convenience for a post-order walk.
+    fn walk_post<F>(&self, callback: F)
+    where
+        F: for<'x,'y> FnMut(OperationRef<'x,'y>) -> WalkAction,
+    {
+        self.walk(WalkOrder::PostOrder, callback)
     }
 }
 


### PR DESCRIPTION
This exposes mlir_sys::mlirOperationWalk as OperationLike::walk, OperationLike::walk_pre, & OperationLike::walk_post

There are `#[test]`s for `walk_pre` & `walk_post`

This addresses #707 