### PR TITLE
Resolve lifetime elision warnings

### DIFF
--- a/macro/src/dialect/operation.rs
+++ b/macro/src/dialect/operation.rs
@@ -189,7 +189,7 @@ impl<'a> Operation<'a> {
         self.attributes().chain(&self.derived_attributes)
     }
 
-    pub fn required_results(&self) -> impl Iterator<Item = &OperationResult> {
+    pub fn required_results(&self) -> impl Iterator<Item = &OperationResult<'_>> {
         if self.can_infer_type {
             Default::default()
         } else {
@@ -198,19 +198,19 @@ impl<'a> Operation<'a> {
         .filter(|field| !field.is_optional())
     }
 
-    pub fn required_operands(&self) -> impl Iterator<Item = &Operand> {
+    pub fn required_operands(&self) -> impl Iterator<Item = &Operand<'_>> {
         self.operands.iter().filter(|field| !field.is_optional())
     }
 
-    pub fn required_regions(&self) -> impl Iterator<Item = &Region> {
+    pub fn required_regions(&self) -> impl Iterator<Item = &Region<'_>> {
         self.regions.iter().filter(|field| !field.is_optional())
     }
 
-    pub fn required_successors(&self) -> impl Iterator<Item = &Successor> {
+    pub fn required_successors(&self) -> impl Iterator<Item = &Successor<'_>> {
         self.successors.iter().filter(|field| !field.is_optional())
     }
 
-    pub fn required_attributes(&self) -> impl Iterator<Item = &Attribute> {
+    pub fn required_attributes(&self) -> impl Iterator<Item = &Attribute<'_>> {
         self.attributes.iter().filter(|field| !field.is_optional())
     }
 

--- a/macro/src/dialect/operation/builder.rs
+++ b/macro/src/dialect/operation/builder.rs
@@ -20,7 +20,7 @@ impl<'a> OperationBuilder<'a> {
         }
     }
 
-    pub const fn operation(&self) -> &Operation {
+    pub const fn operation(&self) -> &Operation<'a> {
         self.operation
     }
 

--- a/melior/src/context.rs
+++ b/melior/src/context.rs
@@ -42,7 +42,7 @@ impl Context {
     }
 
     /// Returns or loads a dialect.
-    pub fn get_or_load_dialect(&self, name: &str) -> Dialect {
+    pub fn get_or_load_dialect(&self, name: &str) -> Dialect<'_> {
         let name = StringRef::new(name);
 
         unsafe { Dialect::from_raw(mlirContextGetOrLoadDialect(self.raw, name.to_raw())) }
@@ -116,7 +116,7 @@ impl Context {
         unsafe { mlirContextDetachDiagnosticHandler(self.to_raw(), id.to_raw()) }
     }
 
-    pub(crate) fn to_ref(&self) -> ContextRef {
+    pub(crate) fn to_ref(&self) -> ContextRef<'_> {
         unsafe { ContextRef::from_raw(self.to_raw()) }
     }
 }

--- a/melior/src/diagnostic.rs
+++ b/melior/src/diagnostic.rs
@@ -22,7 +22,7 @@ pub struct Diagnostic<'c> {
 }
 
 impl Diagnostic<'_> {
-    pub fn location(&self) -> Location {
+    pub fn location(&self) -> Location<'_> {
         unsafe { Location::from_raw(mlirDiagnosticGetLocation(self.raw)) }
     }
 

--- a/melior/src/dialect/handle.rs
+++ b/melior/src/dialect/handle.rs
@@ -77,7 +77,7 @@ impl DialectHandle {
     }
 
     /// Returns a namespace.
-    pub fn namespace(&self) -> StringRef {
+    pub fn namespace(&self) -> StringRef<'_> {
         unsafe { StringRef::from_raw(mlirDialectHandleGetNamespace(self.raw)) }
     }
 

--- a/melior/src/dialect/llvm/attributes.rs
+++ b/melior/src/dialect/llvm/attributes.rs
@@ -13,7 +13,7 @@ pub enum Linkage {
 }
 
 /// Creates an LLVM linkage attribute.
-pub fn linkage(context: &Context, linkage: Linkage) -> Attribute {
+pub fn linkage(context: &Context, linkage: Linkage) -> Attribute<'_> {
     let linkage = match linkage {
         Linkage::Private => "private",
         Linkage::Internal => "internal",

--- a/melior/src/dialect/llvm/type.rs
+++ b/melior/src/dialect/llvm/type.rs
@@ -37,12 +37,12 @@ pub fn function<'c>(
     since = "0.11.0",
     note = "please use the pointer method, all pointers are opaque in LLVM 19"
 )]
-pub fn opaque_pointer(context: &Context) -> Type {
+pub fn opaque_pointer<'c>(context: &'c Context) -> Type<'c> {
     pointer(context, 0)
 }
 
 /// Creates an LLVM pointer type in the given address space.
-pub fn pointer(context: &Context, address_space: u32) -> Type {
+pub fn pointer<'c>(context: &'c Context, address_space: u32) -> Type<'c> {
     unsafe { Type::from_raw(mlirLLVMPointerTypeGet(context.to_raw(), address_space)) }
 }
 
@@ -59,7 +59,7 @@ pub fn r#struct<'c>(context: &'c Context, fields: &[Type<'c>], packed: bool) -> 
 }
 
 /// Creates an LLVM void type.
-pub fn void(context: &Context) -> Type {
+pub fn void(context: &Context) -> Type<'_> {
     unsafe { Type::from_raw(mlirLLVMVoidTypeGet(context.to_raw())) }
 }
 

--- a/melior/src/ir/attribute/attribute_like.rs
+++ b/melior/src/ir/attribute/attribute_like.rs
@@ -19,7 +19,7 @@ pub trait AttributeLike<'c> {
     }
 
     /// Returns a type.
-    fn r#type(&self) -> Type {
+    fn r#type(&self) -> Type<'c> {
         unsafe { Type::from_raw(mlirAttributeGetType(self.to_raw())) }
     }
 

--- a/melior/src/ir/identifier.rs
+++ b/melior/src/ir/identifier.rs
@@ -32,7 +32,7 @@ impl<'c> Identifier<'c> {
     }
 
     /// Converts an identifier into a string reference.
-    pub fn as_string_ref(&self) -> StringRef {
+    pub fn as_string_ref(&self) -> StringRef<'c> {
         unsafe { StringRef::from_raw(mlirIdentifierStr(self.raw)) }
     }
 

--- a/melior/src/ir/type/id/allocator.rs
+++ b/melior/src/ir/type/id/allocator.rs
@@ -17,7 +17,7 @@ impl Allocator {
         }
     }
 
-    pub fn allocate_type_id(&mut self) -> TypeId {
+    pub fn allocate_type_id(&mut self) -> TypeId<'_> {
         unsafe { TypeId::from_raw(mlirTypeIDAllocatorAllocateTypeID(self.raw)) }
     }
 }

--- a/melior/src/ir/type/tuple.rs
+++ b/melior/src/ir/type/tuple.rs
@@ -21,7 +21,7 @@ impl<'c> TupleType<'c> {
     }
 
     /// Returns a field at a position.
-    pub fn r#type(&self, index: usize) -> Result<Type, Error> {
+    pub fn r#type(&self, index: usize) -> Result<Type<'c>, Error> {
         if index < self.type_count() {
             unsafe {
                 Ok(Type::from_raw(mlirTupleTypeGetType(

--- a/melior/src/pass/external.rs
+++ b/melior/src/pass/external.rs
@@ -229,7 +229,7 @@ mod tests {
     #[repr(align(8))]
     struct PassId;
 
-    fn create_module(context: &Context) -> Module {
+    fn create_module<'c>(context: &'c Context) -> Module<'c> {
         let location = Location::unknown(context);
         let module = Module::new(location);
 

--- a/melior/src/pass/manager.rs
+++ b/melior/src/pass/manager.rs
@@ -32,7 +32,7 @@ impl PassManager<'_> {
 
     /// Returns an operation pass manager for nested operations corresponding to
     /// a given name.
-    pub fn nested_under(&self, name: &str) -> OperationPassManager {
+    pub fn nested_under(&self, name: &str) -> OperationPassManager<'_, '_> {
         let name = StringRef::new(name);
 
         unsafe {
@@ -83,7 +83,7 @@ impl PassManager<'_> {
     }
 
     /// Converts a pass manager to an operation pass manager.
-    pub fn as_operation_pass_manager(&self) -> OperationPassManager {
+    pub fn as_operation_pass_manager(&self) -> OperationPassManager<'_, '_> {
         unsafe { OperationPassManager::from_raw(mlirPassManagerGetAsOpPassManager(self.raw)) }
     }
 


### PR DESCRIPTION
Add lifetimes (mostly `'_`) in many places to resolve many instances of the following warning:

    hiding a lifetime that's elided elsewhere is confusing

Of course this warning is harmless, but I hope reducing warning noise can help in spotting more important warnings.

### Testing

It still compiles, and `cargo test` still passes