### PR TITLE
bug(ir-attribute): Fix ArrayAttribute Trait + TryFrom Conversion Tests for All Attributes

### DIFF
--- a/melior/src/ir/attribute/array.rs
+++ b/melior/src/ir/attribute/array.rs
@@ -51,12 +51,16 @@ impl<'c> ArrayAttribute<'c> {
     }
 }
 
-attribute_traits!(ArrayAttribute, is_dense_i64_array, "dense i64 array");
+attribute_traits!(ArrayAttribute, is_array, "array");
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        ir::{Type, attribute::IntegerAttribute, r#type::IntegerType},
+        ir::{
+            Type,
+            attribute::{IntegerAttribute, StringAttribute},
+            r#type::IntegerType,
+        },
         test::create_test_context,
     };
 
@@ -92,5 +96,28 @@ mod tests {
         );
 
         assert_eq!(attribute.len(), 1);
+    }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute = ArrayAttribute::new(
+            &context,
+            &[
+                StringAttribute::new(&context, "hello world").into(),
+                IntegerAttribute::new(Type::index(&context), 1).into(),
+            ],
+        )
+        .into();
+
+        assert!(ArrayAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(ArrayAttribute::try_from(attribute).is_err());
     }
 }

--- a/melior/src/ir/attribute/bool.rs
+++ b/melior/src/ir/attribute/bool.rs
@@ -39,4 +39,20 @@ mod tests {
 
         assert!(value);
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute = BoolAttribute::new(&context, true).into();
+
+        assert!(BoolAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(BoolAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/dense_elements.rs
+++ b/melior/src/ir/attribute/dense_elements.rs
@@ -830,4 +830,21 @@ mod tests {
             Err(Error::ElementExpected { .. })
         ));
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute =
+            DenseElementsAttribute::i32_values(i32_tensor_type(&context, 3), &[1, 2, 3]).into();
+
+        assert!(DenseElementsAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(DenseElementsAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/dense_i32_array.rs
+++ b/melior/src/ir/attribute/dense_i32_array.rs
@@ -79,4 +79,20 @@ mod tests {
 
         assert_eq!(attribute.len(), 3);
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute = DenseI32ArrayAttribute::new(&context, &[1, 2, 3]).into();
+
+        assert!(DenseI32ArrayAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(DenseI32ArrayAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/dense_i64_array.rs
+++ b/melior/src/ir/attribute/dense_i64_array.rs
@@ -79,4 +79,20 @@ mod tests {
 
         assert_eq!(attribute.len(), 3);
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute = DenseI64ArrayAttribute::new(&context, &[1, 2, 3]).into();
+
+        assert!(DenseI64ArrayAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(DenseI64ArrayAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/dictionary.rs
+++ b/melior/src/ir/attribute/dictionary.rs
@@ -123,4 +123,22 @@ mod tests {
         assert_eq!(attribute.element_by_name("baz"), Some(val));
         assert_eq!(attribute.element_by_name("missing"), None);
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let id = Identifier::new(&context, "foo");
+        let val = IntegerAttribute::new(IntegerType::new(&context, 64).into(), 42).into();
+        let attribute: Attribute = DictionaryAttribute::new(&context, &[(id, val)]).into();
+
+        assert!(DictionaryAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(DictionaryAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/flat_symbol_ref.rs
+++ b/melior/src/ir/attribute/flat_symbol_ref.rs
@@ -52,4 +52,20 @@ mod tests {
 
         assert_eq!(value, "foo");
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute = FlatSymbolRefAttribute::new(&context, "foo").into();
+
+        assert!(FlatSymbolRefAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(FlatSymbolRefAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/float.rs
+++ b/melior/src/ir/attribute/float.rs
@@ -90,4 +90,21 @@ mod tests {
 
         assert!(attr.is_none());
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute =
+            FloatAttribute::new(&context, Type::float64(&context), 42.0).into();
+
+        assert!(FloatAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(FloatAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/integer.rs
+++ b/melior/src/ir/attribute/integer.rs
@@ -52,4 +52,21 @@ mod tests {
             42
         );
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute =
+            IntegerAttribute::new(IntegerType::new(&context, 64).into(), 42).into();
+
+        assert!(IntegerAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(IntegerAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/strided_layout.rs
+++ b/melior/src/ir/attribute/strided_layout.rs
@@ -90,4 +90,20 @@ mod tests {
             Err(Error::PositionOutOfBounds { .. })
         ));
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute = StridedLayoutAttribute::new(&context, 0, &[1, 2, 3]).into();
+
+        assert!(StridedLayoutAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(StridedLayoutAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/string.rs
+++ b/melior/src/ir/attribute/string.rs
@@ -63,4 +63,20 @@ mod tests {
 
         assert_eq!(attr.value(), "hello");
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute = StringAttribute::new(&context, "foo").into();
+
+        assert!(StringAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(StringAttribute::try_from(attribute).is_err());
+    }
 }

--- a/melior/src/ir/attribute/type.rs
+++ b/melior/src/ir/attribute/type.rs
@@ -37,4 +37,20 @@ mod tests {
 
         assert_eq!(TypeAttribute::new(r#type).value(), r#type);
     }
+
+    #[test]
+    fn try_from_accepts_its_own_kind() {
+        let context = create_test_context();
+        let attribute: Attribute = TypeAttribute::new(Type::index(&context)).into();
+
+        assert!(TypeAttribute::try_from(attribute).is_ok());
+    }
+
+    #[test]
+    fn try_from_rejects_another_kind() {
+        let context = create_test_context();
+        let attribute = Attribute::unit(&context);
+
+        assert!(TypeAttribute::try_from(attribute).is_err());
+    }
 }


### PR DESCRIPTION
### Summary

Fixes a bug in `ArrayAttribute`'s `attribute_traits!` macro the specified the wrong `is_type` method (previously `is_dense_i64_array`, instead of the `is_array` for `ArrayAttribute`). In addition, to verify the `ArrayAttribute` fix and for completetion, adds `TryFrom` conversion tests to all attributes.

### Context 

Consider on of the new conversion test added for ArrayAttribute. Previously, this test would panic, incorrectly classifing trying to convert the `Attribute` to a `DenseI64ArrayAttribute.
```rust
fn try_from_accepts_its_own_kind() {
    let context = create_test_context();
    let attribute: Attribute = ArrayAttribute::new(
        &context,
        &[
            StringAttribute::new(&context, "hello world").into(),
            IntegerAttribute::new(Type::index(&context), 1).into(),
        ],
    )
    .into();

    assert!(ArrayAttribute::try_from(attribute).is_ok());
}
```
With the attribute change, conversion passes successfully.

Positive and negative tests for `impl TryFrom<...> for Attribute` were added for every attribute type. The positive test asserts that generic attributes can be converted to their specialized type, and the negative test asserts that untyped or incorrect attributed fails to error.