### PR TITLE
Add block and region iterators

### DIFF
--- a/melior/src/ir.rs
+++ b/melior/src/ir.rs
@@ -23,7 +23,7 @@ pub use self::{
     location::Location,
     module::Module,
     operation::{Operation, OperationRef},
-    region::{Region, RegionLike, RegionRef},
+    region::{Region, RegionIterator, RegionLike, RegionRef},
     r#type::{ShapedTypeLike, Type, TypeLike},
     value::{Value, ValueLike},
 };

--- a/melior/src/ir/block.rs
+++ b/melior/src/ir/block.rs
@@ -4,10 +4,11 @@ mod argument;
 mod block_like;
 
 pub use self::{argument::BlockArgument, block_like::BlockLike};
-use super::{Location, Type, TypeLike, Value};
+use super::{Location, OperationRef, Type, TypeLike, Value};
 use crate::{context::Context, utility::print_callback};
 use mlir_sys::{
     MlirBlock, mlirBlockCreate, mlirBlockDestroy, mlirBlockDetach, mlirBlockEqual, mlirBlockPrint,
+    mlirOperationGetNextInBlock,
 };
 use std::{
     ffi::c_void,
@@ -197,6 +198,54 @@ impl Display for BlockRef<'_, '_> {
 impl Debug for BlockRef<'_, '_> {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         Debug::fmt(self.deref(), formatter)
+    }
+}
+
+#[derive(Clone, Copy)]
+#[doc(hidden)]
+pub struct BlockIterator<'c, 'a> {
+    current: Option<OperationRef<'c, 'a>>,
+}
+
+impl<'c, 'a> BlockIterator<'c, 'a> {
+    fn new(block: BlockRef<'c, 'a>) -> Self {
+        Self {
+            current: block.first_operation(),
+        }
+    }
+}
+
+impl<'c, 'a> Iterator for BlockIterator<'c, 'a> {
+    type Item = OperationRef<'c, 'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.current {
+            None => None,
+            Some(op) => {
+                self.current = unsafe {
+                    OperationRef::from_option_raw(mlirOperationGetNextInBlock(op.to_raw()))
+                };
+                Some(op)
+            }
+        }
+    }
+}
+
+impl<'c, 'a> IntoIterator for BlockRef<'c, 'a> {
+    type Item = OperationRef<'c, 'a>;
+    type IntoIter = BlockIterator<'c, 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BlockIterator::new(self)
+    }
+}
+
+impl<'c, 'a> IntoIterator for &'a Block<'c> {
+    type Item = OperationRef<'c, 'a>;
+    type IntoIter = BlockIterator<'c, 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BlockIterator::new(unsafe { BlockRef::from_raw(self.to_raw()) })
     }
 }
 
@@ -511,5 +560,29 @@ mod tests {
                 index: 0,
             }
         );
+    }
+
+    #[test]
+    fn block_iterator() {
+        let context = create_test_context();
+        context.set_allow_unregistered_dialects(true);
+        let block = Block::new(&[]);
+
+        let first_operation = block.append_operation(
+            OperationBuilder::new("foo", Location::unknown(&context))
+                .build()
+                .unwrap(),
+        );
+        let second_operation = block.insert_operation_after(
+            first_operation,
+            OperationBuilder::new("foo", Location::unknown(&context))
+                .build()
+                .unwrap(),
+        );
+
+        let mut iter = block.into_iter();
+        assert_eq!(iter.next(), Some(first_operation));
+        assert_eq!(iter.next(), Some(second_operation));
+        assert_eq!(iter.next(), None);
     }
 }

--- a/melior/src/ir/region.rs
+++ b/melior/src/ir/region.rs
@@ -1,8 +1,10 @@
 mod region_like;
 
 pub use self::region_like::RegionLike;
-use super::Block;
-use mlir_sys::{MlirRegion, mlirRegionCreate, mlirRegionDestroy, mlirRegionEqual};
+use super::{Block, BlockRef};
+use mlir_sys::{
+    MlirRegion, mlirBlockGetNextInRegion, mlirRegionCreate, mlirRegionDestroy, mlirRegionEqual,
+};
 use std::{
     marker::PhantomData,
     mem::{forget, transmute},
@@ -117,6 +119,53 @@ impl PartialEq for RegionRef<'_, '_> {
 
 impl Eq for RegionRef<'_, '_> {}
 
+#[derive(Clone, Copy)]
+#[doc(hidden)]
+pub struct RegionIterator<'c, 'a> {
+    current: Option<BlockRef<'c, 'a>>,
+}
+
+impl<'c, 'a> RegionIterator<'c, 'a> {
+    fn new(region: RegionRef<'c, 'a>) -> Self {
+        Self {
+            current: region.first_block(),
+        }
+    }
+}
+
+impl<'c, 'a> Iterator for RegionIterator<'c, 'a> {
+    type Item = BlockRef<'c, 'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.current {
+            None => None,
+            Some(op) => {
+                self.current =
+                    unsafe { BlockRef::from_option_raw(mlirBlockGetNextInRegion(op.to_raw())) };
+                Some(op)
+            }
+        }
+    }
+}
+
+impl<'c, 'a> IntoIterator for RegionRef<'c, 'a> {
+    type Item = BlockRef<'c, 'a>;
+    type IntoIter = RegionIterator<'c, 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RegionIterator::new(self)
+    }
+}
+
+impl<'c, 'a> IntoIterator for &'a Region<'c> {
+    type Item = BlockRef<'c, 'a>;
+    type IntoIter = RegionIterator<'c, 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RegionIterator::new(unsafe { RegionRef::from_raw(self.to_raw()) })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,5 +220,18 @@ mod tests {
     #[test]
     fn not_equal() {
         assert_ne!(Region::new(), Region::new());
+    }
+
+    #[test]
+    fn region_iterator() {
+        let region = Region::new();
+
+        let block1 = region.append_block(Block::new(&[]));
+        let block2 = region.insert_block_after(block1, Block::new(&[]));
+
+        let mut iter = region.into_iter();
+        assert_eq!(iter.next(), Some(block1));
+        assert_eq!(iter.next(), Some(block2));
+        assert_eq!(iter.next(), None);
     }
 }


### PR DESCRIPTION
I think block and region iterators should really help with programming ergonomics. I have the pub iterator types removed from the docs. @raviqqe Can you check that I am carrying the lifetime information correctly?